### PR TITLE
adjustments for VC-API spec

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -86,8 +86,9 @@ export async function build (opts = {}) {
       try {
         const tenantName = req.params.tenantName // the issuer instance/tenant with which to sign
         const authHeader = req.headers.authorization
-        const unSignedVC = req.body
-
+        const body = req.body
+        const unSignedVC = body.credential ? body.credential : body
+    
         await verifyAuthHeader(authHeader, tenantName)
         // NOTE: we throw the error here which will then be caught by middleware errorhandler
         if (!unSignedVC || !Object.keys(unSignedVC).length) throw new IssuingException(400, 'A verifiable credential must be provided in the body')
@@ -95,7 +96,7 @@ export async function build (opts = {}) {
           ? await callService(`http://${statusService}/credentials/status/allocate`, unSignedVC)
           : unSignedVC
         const signedVC = await callService(`http://${signingService}/instance/${tenantName}/credentials/sign`, vcWithStatus)
-        return res.json(signedVC)
+        return res.status(201).json(signedVC)
       } catch (error) {
         // have to catch async errors and forward error handling
         // middleware

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,10 @@ async function callService (endpoint, body) {
   return data
 }
 
+function isNotValidVC(unSignedVC) {
+  return !unSignedVC || !Object.keys(unSignedVC).length || !unSignedVC.credentialSubject
+}
+
 export async function build (opts = {}) {
   const {
     enableStatusService,
@@ -88,10 +92,10 @@ export async function build (opts = {}) {
         const authHeader = req.headers.authorization
         const body = req.body
         const unSignedVC = body.credential ? body.credential : body
-    
+    422
         await verifyAuthHeader(authHeader, tenantName)
         // NOTE: we throw the error here which will then be caught by middleware errorhandler
-        if (!unSignedVC || !Object.keys(unSignedVC).length) throw new IssuingException(400, 'A verifiable credential must be provided in the body')
+        if (isNotValidVC(unSignedVC)) throw new IssuingException(422, 'A verifiable credential must be provided in the body')
         const vcWithStatus = enableStatusService
           ? await callService(`http://${statusService}/credentials/status/allocate`, unSignedVC)
           : unSignedVC

--- a/src/app.js
+++ b/src/app.js
@@ -22,15 +22,15 @@ async function callService (endpoint, body) {
   return data
 }
 
-function isArrayOfStrings(arrayToCheck) {
-  return arrayToCheck && Array.isArray(arrayToCheck) && arrayToCheck.length && arrayToCheck.every(item=> {return (item && typeof item == "string")})
+function isArrayOfStrings (arrayToCheck) {
+  return arrayToCheck && Array.isArray(arrayToCheck) && arrayToCheck.length && arrayToCheck.every(item => { return (item && typeof item === 'string') })
 }
 
 function isNotValidVC (unSignedVC) {
-  if (!unSignedVC) return true;
+  if (!unSignedVC) return true
   const isContextPropertyValid = isArrayOfStrings(unSignedVC['@context'])
   const isTypePropertyValid = isArrayOfStrings(unSignedVC.type)
-  return ! (isContextPropertyValid && isTypePropertyValid) 
+  return !(isContextPropertyValid && isTypePropertyValid)
 }
 
 export async function build (opts = {}) {

--- a/src/app.js
+++ b/src/app.js
@@ -31,7 +31,8 @@ function isValidVC (unSignedVC) {
   const isContextPropertyValid = isArrayOfStrings(unSignedVC['@context'])
   const isTypePropertyValid = isArrayOfStrings(unSignedVC.type)
   const isIssuerPropertyValid = (unSignedVC.issuer != null) && !Array.isArray(unSignedVC.issuer) && (typeof unSignedVC.issuer === 'string' || typeof unSignedVC.issuer === 'object')
-  return (isContextPropertyValid && isTypePropertyValid && isIssuerPropertyValid)
+  const isCredentialSubjectPropertyValid = (unSignedVC.credentialSubject != null) && !Array.isArray(unSignedVC.credentialSubject) && (typeof unSignedVC.credentialSubject === 'object')
+  return (isContextPropertyValid && isTypePropertyValid && isIssuerPropertyValid && isCredentialSubjectPropertyValid)
 }
 
 export async function build (opts = {}) {

--- a/src/app.js
+++ b/src/app.js
@@ -22,7 +22,7 @@ async function callService (endpoint, body) {
   return data
 }
 
-function isNotValidVC(unSignedVC) {
+function isNotValidVC (unSignedVC) {
   return !unSignedVC || !Object.keys(unSignedVC).length || !unSignedVC.credentialSubject
 }
 
@@ -92,7 +92,6 @@ export async function build (opts = {}) {
         const authHeader = req.headers.authorization
         const body = req.body
         const unSignedVC = body.credential ? body.credential : body
-    422
         await verifyAuthHeader(authHeader, tenantName)
         // NOTE: we throw the error here which will then be caught by middleware errorhandler
         if (isNotValidVC(unSignedVC)) throw new IssuingException(422, 'A verifiable credential must be provided in the body')

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -64,12 +64,12 @@ describe('api', () => {
   })
 
   describe('POST /instance/:instanceId/credentials/issue', () => {
-    it('returns 400 if no body', done => {
+    it('returns 422 if no body', done => {
       request(app)
         .post('/instance/protected_test/credentials/issue')
         .set('Authorization', `Bearer ${testTenantToken}`)
         .expect('Content-Type', /json/)
-        .expect(400, done)
+        .expect(422, done)
     })
 
     it('returns 401 if tenant token is missing from auth header', done => {
@@ -88,7 +88,7 @@ describe('api', () => {
         .send(getUnsignedVC())
 
       expect(response.header['content-type']).to.have.string('json')
-      expect(response.status).to.equal(200)
+      expect(response.status).to.equal(201)
       expect(response.body)
     })
 
@@ -137,7 +137,7 @@ describe('api', () => {
         .send(sentCred)
 
       expect(response.header['content-type']).to.have.string('json')
-      expect(response.status).to.equal(200)
+      expect(response.status).to.equal(201)
 
       const returnedCred = JSON.parse(JSON.stringify(response.body))
       // this proof value comes from the nock:


### PR DESCRIPTION
Various fixes 

- change credentials/issue endpoint to return 201 rather than 200 for successful issuance
- allow post to credentials/issue of either a straight vc or an object with a 'credential' property that contains the vc